### PR TITLE
check currentUser object before its properties

### DIFF
--- a/assets/javascripts/initializers/discourse-silenced-flair.js
+++ b/assets/javascripts/initializers/discourse-silenced-flair.js
@@ -10,7 +10,7 @@ export default {
       const h = require("virtual-dom").h;
       const currentUser = api.getCurrentUser();
 
-      if (!(currentUser.moderator || currentUser.admin)) {
+      if ( !currentUser || (!(currentUser.moderator || currentUser.admin)) ) {
         return;
       }
 


### PR DESCRIPTION
Prevent js error when non-logged users load a discourse forum with this plugin
Issue: https://github.com/chapoi/discourse-silenced-flair/issues/1